### PR TITLE
[FIX] Fixed enterence animation for checkout modal

### DIFF
--- a/frontend/ubre/src/app/layouts/registered-user/registered-user.css
+++ b/frontend/ubre/src/app/layouts/registered-user/registered-user.css
@@ -45,6 +45,7 @@
   left: 16px;
   width: 360px;
   position: fixed;
+  animation: slideUp 0.3s ease-in;
 }
   
 @keyframes slideUp {

--- a/frontend/ubre/src/app/shared/ui/modal-container/modal-container.css
+++ b/frontend/ubre/src/app/shared/ui/modal-container/modal-container.css
@@ -9,6 +9,7 @@
     box-shadow: var(--drop-shadow);
     z-index: 2100;
     pointer-events: auto;
+    transition: transform 0.3s ease-in;
 }
 
 .modal-container > *:first-child:not(.title-bar) {


### PR DESCRIPTION
As stated in the issue, animation for the modal container in checkout modal did not work as intended (modal would not be animated and would just stay in the final state of the animation).